### PR TITLE
Work around a type inference change in javac

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+# This is the official list of pcollections authors for copyright purposes.
+
+Harold Cooper
+Google Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2008 Harold Cooper
+Copyright 2015 The pcollections Authors. All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/pcollections/ConsPStack.java
+++ b/src/main/java/org/pcollections/ConsPStack.java
@@ -49,13 +49,13 @@ public final class ConsPStack<E> extends AbstractSequentialList<E> implements PS
 			return (ConsPStack<E>)list; //(actually we only know it's ConsPStack<? extends E>)
 									// but that's good enough for an immutable
 									// (i.e. we can't mess someone else up by adding the wrong type to it)
-		return from(list.iterator());
+		return ConsPStack.<E>from(list.iterator());
 	}
 	
 	private static <E> ConsPStack<E> from(final Iterator<? extends E> i) {
 		if(!i.hasNext()) return empty();
 		E e = i.next();
-		return from(i).plus(e);
+		return ConsPStack.<E>from(i).plus(e);
 	}
 
 	


### PR DESCRIPTION
The javac compiler's behavior when handling wildcards and "capture" type
variables has been changed in Java 9 [1]. This change allows the code to
be compiled with the latest version of javac.

[1] https://bugs.openjdk.java.net/browse/JDK-8039214