### PR TITLE
Fixed a problem with ConsPStack.minus(int i) - would always remove the first occurrence of an object.

### DIFF
--- a/src/main/java/org/pcollections/ConsPStack.java
+++ b/src/main/java/org/pcollections/ConsPStack.java
@@ -174,7 +174,11 @@ public final class ConsPStack<E> extends AbstractSequentialList<E> implements PS
 	}
 
 	public ConsPStack<E> minus(final int i) {
-		return minus(get(i));
+		if (i < 0 || i >= size)
+			throw new IndexOutOfBoundsException("Index: " + i + "; size: " + size);
+		else if (i == 0)
+			return rest;
+		else return new ConsPStack<E>(first, rest.minus(i-1));
 	}
 
 	public ConsPStack<E> minusAll(final Collection<?> list) {

--- a/src/test/java/org/pcollections/tests/ConsPStackTest.java
+++ b/src/test/java/org/pcollections/tests/ConsPStackTest.java
@@ -3,6 +3,7 @@ package org.pcollections.tests;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.Arrays;
 
 import org.pcollections.ConsPStack;
 import org.pcollections.PStack;
@@ -91,6 +92,22 @@ public class ConsPStackTest extends TestCase {
 					ConsPStack.singleton(10).plusAll(1,UtilityTest.reverse(pstack)).minus(0));
 		}
 	}
+
+    /** Make sure the right element is removed */
+    public void testMinusInt() {
+	// First, let's try a list with distinct elements
+	PStack<String> pstack = ConsPStack.<String>empty().plus("C").plus("B").plus("A");
+	assertEquals(Arrays.asList("A", "B", "C"), pstack);
+	assertEquals(Arrays.asList("B", "C"), pstack.minus(0));
+	assertEquals(Arrays.asList("A", "B"), pstack.minus(2));
+
+	//Now, let's try duplicates
+	pstack = pstack.plus("B");
+	assertEquals(Arrays.asList("B", "A", "B", "C"), pstack);
+	assertEquals(Arrays.asList("A", "B", "C"), pstack.minus(0));
+	assertEquals(Arrays.asList("B", "A", "C"), pstack.minus(2));
+    }
+
 
 	public void testSubListIntInt() {
 		// TODO


### PR DESCRIPTION
The method minus(int i) on ConsPStack was implemented as minus(get(i)). What this effectively does is remove the first occurrence of the object that is the i-th element of the list. This works fine when there are no duplicates, but with duplicates, it will always remove the first occurrence of
the object, even if the index i is that of a subsequent occurrence. So,

ConsPStack.from(Arrays.asList("A", "B", "C", "A")).minus(3) will return B, C, A instead of A, B, C.

Fixed this issue by re-implementing minus(int i) in a recursive manner similar to minus(Object o). Added a test.